### PR TITLE
Fix null pointer exception

### DIFF
--- a/Polyglot.php
+++ b/Polyglot.php
@@ -83,7 +83,9 @@ function wfPolyglotExtension() {
 	global $wgPolyglotLanguages;
 
 	if ( $wgPolyglotLanguages === null ) {
-		$wgPolyglotLanguages = @$GLOBALS['wgLanguageSelectorLanguages'];
+        if (array_key_exists('wgLanguageSelectorLanguages', $GLOBALS)){
+            $wgPolyglotLanguages = @$GLOBALS['wgLanguageSelectorLanguages'];
+        }    
 	}
 
 	if ( $wgPolyglotLanguages === null ) {


### PR DESCRIPTION
Not critical, but warning "Notice: Undefined index: wgLanguageSelectorLanguages" was really annoing if 
if we need to debug something else.
``` 
  $wgDevelopmentWarnings = true; 
  ini_set( 'display_errors', 1);
```
